### PR TITLE
Sha1 is deprecated.

### DIFF
--- a/Formula/ssh-askpass.rb
+++ b/Formula/ssh-askpass.rb
@@ -3,7 +3,7 @@ require "formula"
 class SshAskpass < Formula
   homepage "https://github.com/theseal/ssh-askpass/"
   url "https://github.com/theseal/ssh-askpass/archive/v1.0.2.tar.gz"
-  sha1 "fb92e5be3222d391c20b821b8d489fa896c32976"
+  sha256 "e83f27f016bd0aef360f361f7b6a373a345948fe71dd87807fc97be37c517742"
 
   def install
     bin.install "ssh-askpass"


### PR DESCRIPTION
Homebrew has deprecated sha1, the future is sha256.
Closes #5.
