### PR TITLE
Replace embedded agent plist with actual plist file

### DIFF
--- a/Formula/ssh-askpass.rb
+++ b/Formula/ssh-askpass.rb
@@ -5,46 +5,14 @@ class SshAskpass < Formula
   sha256 "a32e8bccbe44adddab3192cc4263d2c2d7f0fc2613ee80be4fcf46e233cea970"
 
   def install
-    bin.install "ssh-askpass"
+    bin.install "#{name}"
+    prefix.install "#{name}.plist" => "#{plist_name}.plist"
   end
 
   def caveats; <<~EOF
-    NOTE: After you have started the launchd service (read below) you need to log out and in (reboot might be easiest) before you can add keys to the agent with `ssh-add -c`.
+    NOTE: You will need to run the following to load the SSH_ASKPASS environment variable:
+      brew services start #{name}
     EOF
-  end
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-        <dict>
-                <key>Label</key>
-                <string>#{plist_name}</string>
-                <key>ProgramArguments</key>
-                <array>
-                        <string>/usr/bin/ssh-agent</string>
-                        <string>-l</string>
-                </array>
-                <key>EnvironmentVariables</key>
-                <dict>
-                        <key>SSH_ASKPASS</key>
-                        <string>#{opt_bin}/ssh-askpass</string>
-                        <key>DISPLAY</key>
-                        <string>0</string>
-                </dict>
-                <key>Sockets</key>
-                <dict>
-                        <key>Listeners</key>
-                        <dict>
-                                <key>SecureSocketWithKey</key>
-                                <string>SSH_AUTH_SOCK</string>
-                        </dict>
-                </dict>
-                <key>EnableTransactions</key>
-                <true/>
-        </dict>
-        </plist>
-    EOS
   end
 
   test do


### PR DESCRIPTION
Tell homebrew where to find the actual LaunchAgent plist, rather than embedding it in the formula. Alsö, add instructions to caveats block to instruct the user on how to load it. 