### PR TITLE
Remove empty "test"

### DIFF
--- a/Formula/ssh-askpass.rb
+++ b/Formula/ssh-askpass.rb
@@ -46,8 +46,4 @@ class SshAskpass < Formula
         </plist>
     EOS
   end
-
-  test do
-    system "true"
-  end
 end


### PR DESCRIPTION
I'm generally opposed to silencing a warning by adding a dummy block that expressly does *not* do what the warning recommends. If there's no way to test this, then the warning is correct: there's no test. If there is a way to test this, then adding "true" is not a good test.

Some possible options to write a good test: 
- verify that `osascript` runs?
- set some kind of timeout and then run ssh-askpass?
- syntax validation of script?
- syntax validation of plist?

Here's an idea: asynchronously run ssh-askpass with known inputs, then run a second `osascript` which passes "enter" or clicks "OK" to the waiting window, then validate the return value.