### PR TITLE
`brew services` requires a specific name in label

### DIFF
--- a/Formula/ssh-askpass.rb
+++ b/Formula/ssh-askpass.rb
@@ -8,7 +8,7 @@ class SshAskpass < Formula
     bin.install "#{name}"
     # The label in the plist must be #{plist_name} in order for `brew services` to work
     # See https://github.com/Homebrew/homebrew-services/issues/376
-    inreplace "ssh-askpass.plist", /<string>com.github.theseal.ssh-askpass<\/string>/, "<string>homebrew.mxcl.ssh-askpass</string>"
+    inreplace "ssh-askpass.plist", /<string>com.github.theseal.ssh-askpass<\/string>/, "<string>#{plist_name}</string>"
     prefix.install "#{name}.plist" => "#{plist_name}.plist"
   end
 

--- a/Formula/ssh-askpass.rb
+++ b/Formula/ssh-askpass.rb
@@ -4,6 +4,10 @@ class SshAskpass < Formula
   url "https://github.com/theseal/ssh-askpass/archive/v1.4.0.tar.gz"
   sha256 "9f13178d3856e7b280f8cc07bb7e755d8d1cd4ee4411fd48ffaa3235fcef9c32"
 
+  # The label in the plist must be #{plist_name} in order for `brew services` to work
+  # See https://github.com/Homebrew/homebrew-services/issues/376
+  patch :DATA
+
   def install
     bin.install "#{name}"
     prefix.install "#{name}.plist" => "#{plist_name}.plist"
@@ -19,3 +23,17 @@ class SshAskpass < Formula
     system "true"
   end
 end
+__END__
+diff --git a/ssh-askpass.plist b/ssh-askpass.plist
+index af9ab75..d74d0b8 100644
+--- a/ssh-askpass.plist
++++ b/ssh-askpass.plist
+@@ -3,7 +3,7 @@
+ <plist version="1.0">
+     <dict>
+         <key>Label</key>
+-        <string>com.github.theseal.ssh-askpass</string>
++        <string>homebrew.mxcl.ssh-askpass</string>
+         <key>LimitLoadToSessionType</key>
+         <string>Aqua</string>
+         <key>ProgramArguments</key>

--- a/Formula/ssh-askpass.rb
+++ b/Formula/ssh-askpass.rb
@@ -4,12 +4,11 @@ class SshAskpass < Formula
   url "https://github.com/theseal/ssh-askpass/archive/v1.4.0.tar.gz"
   sha256 "9f13178d3856e7b280f8cc07bb7e755d8d1cd4ee4411fd48ffaa3235fcef9c32"
 
-  # The label in the plist must be #{plist_name} in order for `brew services` to work
-  # See https://github.com/Homebrew/homebrew-services/issues/376
-  patch :DATA
-
   def install
     bin.install "#{name}"
+    # The label in the plist must be #{plist_name} in order for `brew services` to work
+    # See https://github.com/Homebrew/homebrew-services/issues/376
+    inreplace "ssh-askpass.plist", /<string>com.github.theseal.ssh-askpass<\/string>/, "<string>homebrew.mxcl.ssh-askpass</string>"
     prefix.install "#{name}.plist" => "#{plist_name}.plist"
   end
 
@@ -23,17 +22,3 @@ class SshAskpass < Formula
     system "true"
   end
 end
-__END__
-diff --git a/ssh-askpass.plist b/ssh-askpass.plist
-index af9ab75..d74d0b8 100644
---- a/ssh-askpass.plist
-+++ b/ssh-askpass.plist
-@@ -3,7 +3,7 @@
- <plist version="1.0">
-     <dict>
-         <key>Label</key>
--        <string>com.github.theseal.ssh-askpass</string>
-+        <string>homebrew.mxcl.ssh-askpass</string>
-         <key>LimitLoadToSessionType</key>
-         <string>Aqua</string>
-         <key>ProgramArguments</key>


### PR DESCRIPTION
Not sure if I makes this to complicated but I don't like having duplicate files
in diffrent repos and don't want to take the Homebrew namespace to an external
repo.

Trying to fix https://github.com/theseal/ssh-askpass/issues/36 and it seems according to
https://github.com/Homebrew/homebrew-services/issues/376
that a service in brew needs to have the same name in label as the file name.